### PR TITLE
27:   when package is devDependencies, add to devDependencies in root

### DIFF
--- a/src/main/dedupe.ts
+++ b/src/main/dedupe.ts
@@ -12,8 +12,12 @@ const adjustLernaBootstrap = async (currentValue: string, newValue: string) => {
     }
 }
 
-const addToRoot = async (packageName: string, maxVersion: string): Promise<void> => {
-    shell.exec(`npm install ${packageName}@${maxVersion} --save-exact > /dev/null 2>&1`)
+const addToRoot = async (packageName: string, maxVersion: string, isDevDependency: boolean): Promise<void> => {
+    if (isDevDependency) {
+        shell.exec(`npm install ${packageName}@${maxVersion} --save-exact --save-dev > /dev/null 2>&1`)
+    } else {
+        shell.exec(`npm install ${packageName}@${maxVersion} --save-exact > /dev/null 2>&1`)
+    }
 }
 
 const install = async () => {

--- a/src/main/dedupe.ts
+++ b/src/main/dedupe.ts
@@ -13,11 +13,8 @@ const adjustLernaBootstrap = async (currentValue: string, newValue: string) => {
 }
 
 const addToRoot = async (packageName: string, maxVersion: string, isDevDependency: boolean): Promise<void> => {
-    if (isDevDependency) {
-        shell.exec(`npm install ${packageName}@${maxVersion} --save-exact --save-dev > /dev/null 2>&1`)
-    } else {
-        shell.exec(`npm install ${packageName}@${maxVersion} --save-exact > /dev/null 2>&1`)
-    }
+    const saveDev: string = isDevDependency ? `--save-dev` : ""
+    shell.exec(`npm install ${packageName}@${maxVersion} --save-exact ${saveDev} > /dev/null 2>&1`)
 }
 
 const install = async () => {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -45,14 +45,14 @@ const resolveDependencyParam = (dependencyParam: string) => {
     }
 }
 
+/**
+ * Returns "true" if all dependency attributes in all found versions are of "devDependencies" type.
+ * If any are of "dependencies" type, add as "dependencies".
+ * @param foundVersions Array of objects - All versions in all packages found for "dependency"
+ * @returns Boolean
+ */
 const isDevDependency = (foundVersions: FoundVersion[]): boolean => {
-    let isDevDependency: boolean
-
-    foundVersions.forEach(({ packages }) => {
-        isDevDependency = packages.some(({ dependencyAttribute }) => dependencyAttribute === "devDependencies")
-    })
-
-    return isDevDependency
+    return foundVersions.every(({ packages }) => packages.every(({ dependencyAttribute }) => dependencyAttribute === "devDependencies"))
 }
 
 const main = async (dependencyParams: string[], options: OptionValues, ...others): Promise<void> => {


### PR DESCRIPTION
Put together this solution as a first go in regards to https://github.com/zensurance/deup/issues/27.

I wasn't sure if always adding to "dependencies" in root was intentional.  If it was we can always close the ticket.  If not, this is an attempt to solve that issue.

Let me know what you think!